### PR TITLE
Add ghc-options to package.yml instead of passing --pedantic to stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: build run test lint format clean docker-deps docker-build
 
 build:
-	stack build --pedantic --install-ghc --allow-different-user
+	stack build --install-ghc --allow-different-user
 
 run: build
 	stack exec effects-exe
 
 test:
-	stack test --pedantic --install-ghc --allow-different-user
+	stack test --install-ghc --allow-different-user
 
 lint:
 	hlint .

--- a/package.yaml
+++ b/package.yaml
@@ -16,6 +16,10 @@ description: >
 dependencies:
 - base >= 4.7 && < 5
 
+ghc-options:
+- -Wall
+- -Werror
+
 library:
   source-dirs: src
   dependencies:


### PR DESCRIPTION
Add `ghc-options` to `package.yml` instead of passing `--pedantic` to stack. Now anyone can run `stack build` with no extra flags and get consistent results.