### PR TITLE
Turn on more GHC warnings

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,11 @@ dependencies:
 
 ghc-options:
 - -Wall
+- -Wcompat
 - -Werror
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wredundant-constraints
 
 library:
   source-dirs: src


### PR DESCRIPTION
Turn on more GHC warnings.

These were recommended by
https://lexi-lambda.github.io/blog/2018/02/10/an-opinionated-guide-to-haskell-in-2018/.