### PR TITLE
Remove instances of `pure ()`

### DIFF
--- a/src/ExtensibleEffects.hs
+++ b/src/ExtensibleEffects.hs
@@ -61,7 +61,6 @@ program =
     logOutput (show i ++ "\n")
     r <- getRandom
     setAccumulator (r + i)
-    pure ()
 
 -- A custom effect handler
 runRandom :: Eff (Random ': r) a -> Eff r a

--- a/src/FreeMonad.hs
+++ b/src/FreeMonad.hs
@@ -52,7 +52,6 @@ program =
     logOutput (show i ++ "\n")
     r <- getRandom
     setAccumulator (r + i)
-    pure ()
 
 -- An interpreter
 transform :: Operations a -> MonadTransformers.Computation a

--- a/src/MonadTransformers.hs
+++ b/src/MonadTransformers.hs
@@ -51,7 +51,6 @@ program =
     logOutput (show i ++ "\n")
     r <- getRandom
     setAccumulator (r + i)
-    pure ()
 
 -- An interpreter
 interpret :: Computation a -> (a, String)


### PR DESCRIPTION
Remove instances of `pure ()`. @StevenXL pointed out in https://github.com/stepchowfun/effects/pull/32 that they are unnecessary.