### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/BespokeMonad.hs
+++ b/src/BespokeMonad.hs
@@ -18,7 +18,7 @@ module BespokeMonad
  -
  - [2] Philip Wadler. 1990. Comprehending monads. In Proceedings of the 1990
  -     ACM conference on LISP and functional programming (LFP '90). ACM, New
- -     York, NY, USA, 61-78. DOI=http://dx.doi.org/10.1145/91556.91592
+ -     York, NY, USA, 61-78. DOI=https://doi.org/10.1145/91556.91592
  -}
 import Control.Monad (ap, replicateM_)
 import System.Random (StdGen, mkStdGen, randomR)

--- a/src/ExtensibleEffects.hs
+++ b/src/ExtensibleEffects.hs
@@ -18,12 +18,12 @@ module ExtensibleEffects
  - [1] Oleg Kiselyov, Amr Sabry, and Cameron Swords. 2013. Extensible effects:
  -     an alternative to monad transformers. In Proceedings of the 2013 ACM
  -     SIGPLAN symposium on Haskell (Haskell '13). ACM, New York, NY, USA,
- -     59-70. DOI=http://dx.doi.org/10.1145/2503778.2503791
+ -     59-70. DOI=https://doi.org/10.1145/2503778.2503791
  -
  - [2] Oleg Kiselyov and Hiromi Ishii. 2015. Freer monads, more extensible
  -     effects. In Proceedings of the 2015 ACM SIGPLAN Symposium on Haskell
  -     (Haskell '15). ACM, New York, NY, USA, 94-105.
- -     DOI=http://dx.doi.org/10.1145/2804302.2804319
+ -     DOI=https://doi.org/10.1145/2804302.2804319
  -}
 import Control.Eff (Eff, Member, run)
 import Control.Eff.Extend (handle_relay_s, send)

--- a/src/FreeMonad.hs
+++ b/src/FreeMonad.hs
@@ -10,7 +10,7 @@ module FreeMonad
  - to structure programs was popularized by [1].
  -
  - [1] Wouter Swierstra. 2008. Data types à la carte. J. Funct. Program. 18, 4
- -     (July 2008), 423-436. DOI=http://dx.doi.org/10.1017/S0956796808006758
+ -     (July 2008), 423-436. DOI=https://doi.org/10.1017/S0956796808006758
  -}
 import Control.Monad (replicateM_)
 import Control.Monad.Free (Free(..), foldFree, liftF)

--- a/src/MonadTransformers.hs
+++ b/src/MonadTransformers.hs
@@ -13,7 +13,7 @@ module MonadTransformers
  - [1] Sheng Liang, Paul Hudak, and Mark Jones. 1995. Monad transformers and
  -     modular interpreters. In Proceedings of the 22nd ACM SIGPLAN-SIGACT
  -     symposium on Principles of programming languages (POPL '95). ACM, New
- -     York, NY, USA, 333-343. DOI=http://dx.doi.org/10.1145/199448.199528
+ -     York, NY, USA, 333-343. DOI=https://doi.org/10.1145/199448.199528
  -}
 import Control.Monad (replicateM_)
 import Control.Monad.Random


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!