### PR TITLE
Use `docker_repo` instead of `docker` in the Toast action in the GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
       if: github.event_name == 'push'
-    - uses: stepchowfun/toast/.github/actions/toast@master
+    - uses: stepchowfun/toast/.github/actions/toast@main
       with:
         tasks: build test lint run
-        repo: stephanmisc/toast
+        docker_repo: stephanmisc/toast
         write_remote_cache: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Use `docker_repo` instead of `docker` in the Toast action in the GitHub workflow.

**Status:** Ready

**Fixes:** N/A